### PR TITLE
adding int type to argparse arguments nodes and tasks per node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # lonestar5_launch
-udpates to parametric launcher on TACC/lonestar5
+updates to parametric launcher on TACC/lonestar5
 
 # behavior
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # lonestar5_launch
 updates to parametric launcher on TACC/lonestar5
 
+# load module
+
+      module use /corral-repl/utexas/poldracklab/users/wtriplet/external/ls5_launch
+      module load poldracklaunch
+
+
 # behavior
 ```
 usage: launch [-h] [-s SCRIPT_NAME] [-r RUNTIME] [-j JOBNAME] [-A PROJNAME]

--- a/launch
+++ b/launch
@@ -32,7 +32,7 @@ parser.add_argument('-t','--test',help='do not actually launch job',dest='test',
 
 parser.add_argument('-i','--hold_jid', help='wait for this job id to complete before launching', dest='hold', default=None)
 parser.add_argument('-N','--nodes',type=int, help = 'request that a minimum number of nodes be allocated to this job', dest = 'nodes', default = None)
-parser.add_argument('-n','--max-cores-per-node', help='request that a maximum number of cores be used per node (for memorys sake)', dest = 'max_cores_per_node', default = None)
+parser.add_argument('-n','--max-cores-per-node', type=int, help='request that a maximum number of cores be used per node (for memorys sake)', dest = 'max_cores_per_node', default = None)
 
 class C(object):
     pass

--- a/launch
+++ b/launch
@@ -31,7 +31,7 @@ parser.add_argument('-u','--ignoreuser',help='ignore ~/.launch_user',dest='ignor
 parser.add_argument('-t','--test',help='do not actually launch job',dest='test', action="store_true",default=False)
 
 parser.add_argument('-i','--hold_jid', help='wait for this job id to complete before launching', dest='hold', default=None)
-parser.add_argument('-N','--nodes', help = 'request that a minimum number of nodes be allocated to this job', dest = 'nodes', default = None)
+parser.add_argument('-N','--nodes',type=int, help = 'request that a minimum number of nodes be allocated to this job', dest = 'nodes', default = None)
 parser.add_argument('-n','--max-cores-per-node', help='request that a maximum number of cores be used per node (for memorys sake)', dest = 'max_cores_per_node', default = None)
 
 class C(object):

--- a/poldracklaunch.lua
+++ b/poldracklaunch.lua
@@ -1,0 +1,16 @@
+help(
+[[
+The poldracklaunch module adds the
+location of the launcher.slurm template respectively.
+Version 1.0.0
+]]
+)
+
+whatis("Name: Poldracklab Launch")
+whatis("Version: 1.0.0")
+whatis("Category: tools")
+whatis("Keywords: Launch, Poldracklab, SLURM")
+whatis("URL: http://github.com/wtriplett/lonestar5_launch")
+whatis("Description: Launcher interface for PoldrackLab")
+
+prepend_path("PATH","/corral-repl/utexas/poldracklab/users/wtriplet/external/ls5_launch")


### PR DESCRIPTION
Each of "node" and "tasks_per_node" is parsed as a number (eg %d) in the script to execute the launch, so they should be input as ints. This will close #1 
